### PR TITLE
En annen returkode enn 201 når det opprettes time-event med status error

### DIFF
--- a/race_service/views/time_events.py
+++ b/race_service/views/time_events.py
@@ -5,7 +5,6 @@ import logging
 import os
 from typing import List
 
-from aiohttp import hdrs
 from aiohttp.web import (
     HTTPBadRequest,
     HTTPNotFound,
@@ -14,7 +13,6 @@ from aiohttp.web import (
     View,
 )
 from dotenv import load_dotenv
-from multidict import MultiDict
 
 from race_service.adapters import UsersAdapter
 from race_service.models import Changelog, TimeEvent
@@ -117,11 +115,9 @@ class TimeEventsView(View):
         except (CouldNotCreateTimeEventException) as e:
             raise HTTPBadRequest(reason=str(e)) from e
         logging.debug(f"inserted document with time_event_id {time_event_id}")
-        headers = MultiDict(
-            [(hdrs.LOCATION, f"{BASE_URL}/time-events/{time_event_id}")]
-        )
 
-        return Response(status=201, headers=headers)
+        body = time_event.to_json()
+        return Response(status=200, body=body, content_type="application/json")
 
 
 class TimeEventView(View):

--- a/tests/contract/test_race_results.py
+++ b/tests/contract/test_race_results.py
@@ -414,12 +414,11 @@ async def set_up_context(
         request_body = json.dumps(new_time_event, indent=4, sort_keys=True, default=str)
         url = f"{http_service}/time-events"
         async with session.post(url, headers=headers, data=request_body) as response:
-            assert response.status == 201, "POST of new_time_event failed."
-            assert (
-                "/time-events/" in response.headers[hdrs.LOCATION]
-            ), "Location header has wrong content."
+            assert response.status == 200, "POST of new_time_event failed."
+            new_time_event = await response.json()
+            assert new_time_event["status"] == "OK"
 
-        time_event_url = response.headers[hdrs.LOCATION]
+        time_event_url = f'{http_service}/time-events/{new_time_event["id"]}'
         return time_event_url
 
 

--- a/tests/contract/test_time_events.py
+++ b/tests/contract/test_time_events.py
@@ -413,10 +413,9 @@ async def test_create_time_event(
     async with ClientSession() as session:
         url = f"{http_service}/time-events"
         async with session.post(url, headers=headers, data=request_body) as response:
-            assert response.status == 201, "POST of new_time_event failed."
-            assert (
-                "/time-events/" in response.headers[hdrs.LOCATION]
-            ), "Location header has wrong content."
+            assert response.status == 200, "POST of new_time_event failed."
+            body = await response.json()
+            assert body["status"] == "OK"
 
         # We check that the race has a race_result for the given timing point:
         url = f'{http_service}/races/{new_time_event["race_id"]}'

--- a/tests/integration/test_time_events.py
+++ b/tests/integration/test_time_events.py
@@ -167,7 +167,7 @@ async def test_create_time_event(
     new_time_event: dict,
     time_event: dict,
 ) -> None:
-    """Should return OK, and a header containing time_event_id."""
+    """Should return 200 OK, and a body containing the new time-event."""
     TIME_EVENT_ID = time_event["id"]
     mocker.patch(
         "race_service.services.time_events_service.create_id",
@@ -220,8 +220,10 @@ async def test_create_time_event(
     with aioresponses(passthrough=["http://127.0.0.1"]) as m:
         m.post("http://users.example.com:8081/authorize", status=204)
         resp = await client.post("/time-events", headers=headers, data=request_body)
-        assert resp.status == 201
-        assert f"/time-events/{TIME_EVENT_ID}" in resp.headers[hdrs.LOCATION]
+        assert resp.status == 200
+
+        new_time_event = await resp.json()
+        assert new_time_event["status"] == "OK"
 
 
 @pytest.mark.integration
@@ -234,7 +236,7 @@ async def test_create_time_event_race_result_not_found(
     new_time_event: dict,
     time_event: dict,
 ) -> None:
-    """Should return OK, and a header containing time_event_id."""
+    """Should return 200 OK, and a body containing the new time-event."""
     TIME_EVENT_ID = time_event["id"]
     race_result_ID = "new_race_result"
     mocker.patch(
@@ -292,8 +294,10 @@ async def test_create_time_event_race_result_not_found(
     with aioresponses(passthrough=["http://127.0.0.1"]) as m:
         m.post("http://users.example.com:8081/authorize", status=204)
         resp = await client.post("/time-events", headers=headers, data=request_body)
-        assert resp.status == 201
-        assert f"/time-events/{TIME_EVENT_ID}" in resp.headers[hdrs.LOCATION]
+        assert resp.status == 200
+
+        new_time_event = await resp.json()
+        assert new_time_event["status"] == "OK"
 
 
 @pytest.mark.integration
@@ -307,7 +311,7 @@ async def test_create_time_event_contestant_not_in_race(
     new_time_event: dict,
     time_event: dict,
 ) -> None:
-    """Should return OK, and a header containing time_event_id."""
+    """Should return 200 OK, and a body containing the new time-event."""
     TIME_EVENT_ID = time_event["id"]
     start_entry_wrong_bib = deepcopy(start_entry)
     start_entry_wrong_bib["bib"] = 1000
@@ -363,8 +367,10 @@ async def test_create_time_event_contestant_not_in_race(
     with aioresponses(passthrough=["http://127.0.0.1"]) as m:
         m.post("http://users.example.com:8081/authorize", status=204)
         resp = await client.post("/time-events", headers=headers, data=request_body)
-        assert resp.status == 201
-        assert f"/time-events/{TIME_EVENT_ID}" in resp.headers[hdrs.LOCATION]
+        assert resp.status == 200
+
+        new_time_event = await resp.json()
+        assert new_time_event["status"] == "Error"
 
 
 @pytest.mark.integration
@@ -613,7 +619,7 @@ async def test_create_time_event_race_not_found(
     new_time_event: dict,
     time_event: dict,
 ) -> None:
-    """Should return OK, and a header containing time_event_id, status=Error."""
+    """Should return 200 OK, and a body containing the new time-event, status=Error."""
     TIME_EVENT_ID = time_event["id"]
     mocker.patch(
         "race_service.services.time_events_service.create_id",
@@ -662,8 +668,10 @@ async def test_create_time_event_race_not_found(
     with aioresponses(passthrough=["http://127.0.0.1"]) as m:
         m.post("http://users.example.com:8081/authorize", status=204)
         resp = await client.post("/time-events", headers=headers, data=request_body)
-        assert resp.status == 201
-        assert f"/time-events/{TIME_EVENT_ID}" in resp.headers[hdrs.LOCATION]
+        assert resp.status == 200
+
+        new_time_event = await resp.json()
+        assert new_time_event["status"] == "Error"
 
 
 @pytest.mark.integration
@@ -676,7 +684,7 @@ async def test_create_time_event_does_not_reference_race(
     new_time_event: dict,
     time_event: dict,
 ) -> None:
-    """Should return OK, and a header containing time_event_id, status=Error."""
+    """Should return 200 OK, and a body containing the new time-event, status=Error."""
     TIME_EVENT_ID = time_event["id"]
     time_event_with_no_race_reference = deepcopy(new_time_event)
     time_event_with_no_race_reference["race_id"] = None
@@ -729,8 +737,10 @@ async def test_create_time_event_does_not_reference_race(
     with aioresponses(passthrough=["http://127.0.0.1"]) as m:
         m.post("http://users.example.com:8081/authorize", status=204)
         resp = await client.post("/time-events", headers=headers, data=request_body)
-        assert resp.status == 201
-        assert f"/time-events/{TIME_EVENT_ID}" in resp.headers[hdrs.LOCATION]
+        assert resp.status == 200
+
+        new_time_event = await resp.json()
+        assert new_time_event["status"] == "Error"
 
 
 @pytest.mark.integration
@@ -743,7 +753,7 @@ async def test_create_time_event_is_not_identifiable(
     new_time_event: dict,
     time_event: dict,
 ) -> None:
-    """Should return OK, and a header containing time_event_id, status=Error."""
+    """Should return 200 OK, and a body containing the new time-event, status=Error."""
     TIME_EVENT_ID = time_event["id"]
     time_event_with_no_id = deepcopy(new_time_event)
     time_event_with_no_id["id"] = None
@@ -794,8 +804,10 @@ async def test_create_time_event_is_not_identifiable(
     with aioresponses(passthrough=["http://127.0.0.1"]) as m:
         m.post("http://users.example.com:8081/authorize", status=204)
         resp = await client.post("/time-events", headers=headers, data=request_body)
-        assert resp.status == 201
-        assert f"/time-events/{TIME_EVENT_ID}" in resp.headers[hdrs.LOCATION]
+        assert resp.status == 200
+
+        new_time_event = await resp.json()
+        assert new_time_event["status"] == "Error"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Fixes #83
Ny status-kode ved vellykka POST vil no vere 200 OK, og den nye time-eventen vil kome i responsens body, inkl evt feilmeldinger.
Merk at url til ny time-event vil ikkje lenger kome i location-header.
Dersom status er forskjellig frå "OK", vil det ligge ein feilmelding i changeloggens comment-attributt.