### PR TITLE
Validering av kjøreplan

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -20,6 +20,51 @@ nox.options.sessions = (
 )
 
 
+@session(python=["3.10"])
+def clean(session: Session) -> None:
+    """Clean the project."""
+    session.run(
+        "py3clean",
+        ".",
+        external=True,
+    )
+    session.run(
+        "rm",
+        "-rf",
+        ".cache",
+        external=True,
+    )
+    session.run(
+        "rm",
+        "-rf",
+        ".pytest_cache",
+        external=True,
+    )
+    session.run(
+        "rm",
+        "-rf",
+        ".pytype",
+        external=True,
+    )
+    session.run(
+        "rm",
+        "-rf",
+        "dist",
+        external=True,
+    )
+    session.run(
+        "rm",
+        "-rf",
+        ".mypy_cache",
+        external=True,
+    )
+    session.run(
+        "rm",
+        ".coverage",
+        external=True,
+    )
+
+
 @session(python="3.10")
 def unit_tests(session: Session) -> None:
     """Run the unit test suite."""

--- a/race_service/app.py
+++ b/race_service/app.py
@@ -4,7 +4,8 @@ import os
 from typing import Any
 
 from aiohttp import web
-from aiohttp_middlewares import cors_middleware, error_middleware
+from aiohttp_middlewares.cors import cors_middleware
+from aiohttp_middlewares.error import error_middleware
 import motor.motor_asyncio
 
 from .views import (
@@ -24,6 +25,7 @@ from .views import (
     StartlistView,
     TimeEventsView,
     TimeEventView,
+    ValidateRaceplanView,
 )
 
 
@@ -53,6 +55,7 @@ async def create_app() -> web.Application:
                 "/raceplans/generate-raceplan-for-event", GenerateRaceplanForEventView
             ),
             web.view("/raceplans/{raceplanId}", RaceplanView),
+            web.view("/raceplans/{raceplanId}/validate", ValidateRaceplanView),
             web.view("/races", RacesView),
             web.view("/races/{raceId}", RaceView),
             web.view("/races/{raceId}/race-results", RaceResultsView),
@@ -91,6 +94,6 @@ async def create_app() -> web.Application:
 
         mongo.close()
 
-    app.cleanup_ctx.append(mongo_context)
+    app.cleanup_ctx.append(mongo_context)  # type: ignore
 
     return app

--- a/race_service/services/__init__.py
+++ b/race_service/services/__init__.py
@@ -11,6 +11,7 @@ from .raceplans_service import (
     RaceplanAllreadyExistException,
     RaceplanNotFoundException,
     RaceplansService,
+    validate_raceplan,
 )
 from .races_service import (
     RaceNotFoundException,

--- a/race_service/views/__init__.py
+++ b/race_service/views/__init__.py
@@ -2,7 +2,7 @@
 from .liveness import Ping, Ready
 from .race_results import RaceResultsView, RaceResultView
 from .raceplans import RaceplansView, RaceplanView
-from .raceplans_commands import GenerateRaceplanForEventView
+from .raceplans_commands import GenerateRaceplanForEventView, ValidateRaceplanView
 from .races import RacesView, RaceView
 from .start_entries import StartEntriesView, StartEntryView
 from .startlists import StartlistsView, StartlistView

--- a/tests/contract/test_raceplans.py
+++ b/tests/contract/test_raceplans.py
@@ -397,6 +397,29 @@ async def test_get_raceplan(
 
 @pytest.mark.contract
 @pytest.mark.asyncio
+async def test_validate_raceplan(
+    http_service: Any, token: MockFixture, context: dict
+) -> None:
+    """Should return 200 OK and and a body with a list of results."""
+    raceplan_id = context["id"]
+    url = f"{http_service}/raceplans/{raceplan_id}/validate"
+    headers = {
+        hdrs.AUTHORIZATION: f"Bearer {token}",
+    }
+    session = ClientSession()
+    async with session.post(url, headers=headers) as response:
+        status = response.status
+        results = await response.json()
+    await session.close()
+
+    assert status == 200
+    assert "application/json" in response.headers[hdrs.CONTENT_TYPE]
+    assert type(results) is dict
+    assert len(results) == 0
+
+
+@pytest.mark.contract
+@pytest.mark.asyncio
 async def test_update_race(
     http_service: Any, token: MockFixture, context: dict
 ) -> None:


### PR DESCRIPTION
Fixes #118

Validerer:
- at race ikkje har 0 contestants
- at races er i kronlogisk rekkefølge
- at antall contestants i race stemmer med raceplan
- at antall contestants stemmer med ageclasses

Når validering (POST) går bra, vil ein kunne få eit resultat som følger, dersom det fins feil. Resultat er dict, med nøkkel lik order til det enkelte race, og spesialtilfelle "0", som er feil i sjølve raceplan-objektet:
```
{
    "0": [
        "The sum of contestants in races (24) is not equal to the number of contestants in the raceplan (32)."
    ],
    "4": ["Start time is not in chronological order.", "Race has no contestants."],
}
```